### PR TITLE
update required argument for channel/group creation to name

### DIFF
--- a/api-endpoints.json
+++ b/api-endpoints.json
@@ -68,7 +68,7 @@
           "required": true,
           "description": "Authentication token (Requires scope: read)"
         },
-        "channel": {
+        "name": {
           "required": true,
           "description": "Name of channel to create"
         }
@@ -758,7 +758,7 @@
           "required": true,
           "description": "Authentication token (Requires scope: post)"
         },
-        "channel": {
+        "name": {
           "required": true,
           "description": "Name of group to create"
         }


### PR DESCRIPTION
`channel` is now `name` since it accepts the group/channel _name_, not the _id_.
See the Slack API Docs below for confirmation:

https://api.slack.com/methods/groups.create
https://api.slack.com/methods/channels.create
