### PR TITLE
fixed the channels api and parameter to create channel

### DIFF
--- a/api-endpoints.json
+++ b/api-endpoints.json
@@ -31,7 +31,7 @@
       }
     }
   },
-  "channel": {
+  "channels": {
     "archive": {
       "url": "https://slack.com/api/channels.archive",
       "description": "This method archives a channel.",
@@ -68,7 +68,7 @@
           "required": true,
           "description": "Authentication token (Requires scope: read)"
         },
-        "channel": {
+        "name": {
           "required": true,
           "description": "Name of channel to create"
         }


### PR DESCRIPTION
Name of the channels endpoint is channels not channel corrected that and the parameter name is name, not channel, corrected that as well. 

ref:
https://api.slack.com/methods/channels.create

let me know if you want me to add unit test, can do that later though :), would be great if you can update the npm package repo
